### PR TITLE
Fixed Bug: excessive size of generated .wav Files

### DIFF
--- a/src/pipeline/dataset.py
+++ b/src/pipeline/dataset.py
@@ -28,7 +28,7 @@ import torchaudio
 from scipy.signal import get_window
 import random
 
-from .utils import SuperpositionType
+from .utils import SuperpositionType,normalize_signal
 
 logging.basicConfig(level=logging.INFO)
 
@@ -428,6 +428,7 @@ class EcossDataset:
             split = row["split"]
             # Extract only the label segment
             signal = original_signal[int(original_sr*row["tmin"]):int(original_sr*row["tmax"])]
+            signal = normalize_signal(signal)
             logger.debug(f"{signal}")
             if self.window:
                 signal = signal * get_window('hamming', len(signal))
@@ -644,7 +645,7 @@ class EcossDataset:
             # Save each segment as a separate wave file
             for idx, segment in enumerate(segments):
                 saving_filename = str(filename) + '-' + f"{idx:03d}" + '.wav'
-                sf.write(saving_filename, segment, int(self.sr),"DOUBLE")
+                sf.write(saving_filename, segment, int(self.sr))
         else:
             raise ValueError(f"saving_on_disk should be pickle or wav, not {self.saving_on_disk}")
 

--- a/src/pipeline/utils.py
+++ b/src/pipeline/utils.py
@@ -546,4 +546,8 @@ class LibrosaSpec(nn.Module):
         S_normalized = (S_dB - S_dB.min()) / (S_dB.max() - S_dB.min())  # Data between 0 and 1
         return torch.Tensor(S_normalized).to(self.device)
 
-        
+def normalize_signal(x : np.ndarray):
+    x = x - np.mean(x)
+    max_dev = np.max(np.abs(x))
+
+    return (x) / (max_dev)


### PR DESCRIPTION
In [d0d2b](https://github.com/soundsignature/WP3_T7/commit/d0d2b84f7b74f6b9629bfb2d4968e66174b72a1c), the issue of precision loss when storing in .wav format was addressed. However, this fix resulted in new .wav files being excessively large.

The root cause was that the original signal values were too close to zero. While storing these values in `float64` presented no issues, converting them to 16-bit format led to significant information loss. 

To resolve this, a data normalization process has been introduced. This process effectively utilizes the full range of possible values, thus minimizing information loss and reducing file size.

Preliminary testing indicates that this normalization does not affect the overall results, at least for Effat model, although an exhaustive test has not been performed.
